### PR TITLE
FileInfoExtensions: add WriteAllText

### DIFF
--- a/FileInfoExtensions/FileInfoExtensions.cs
+++ b/FileInfoExtensions/FileInfoExtensions.cs
@@ -217,6 +217,13 @@ namespace System.IO
             writer.Write(buffer);
         }
 
+
+        public static void WriteAllText(this FileInfo file, string text)
+        {
+            using var writer = file.CreateText();
+            return reader.Write(text);
+        }
+        
         public static FileStream Append(this FileInfo File) => File.Open(FileMode.Append, FileAccess.Write);
 
         #endregion

--- a/FileInfoExtensions/FileInfoExtensions.cs
+++ b/FileInfoExtensions/FileInfoExtensions.cs
@@ -221,7 +221,7 @@ namespace System.IO
         public static void WriteAllText(this FileInfo file, string text)
         {
             using var writer = file.CreateText();
-            return reader.Write(text);
+            return writer.Write(text);
         }
         
         public static FileStream Append(this FileInfo File) => File.Open(FileMode.Append, FileAccess.Write);


### PR DESCRIPTION
Я считаю, что мы должны обслужить все методы класса [File](https://docs.microsoft.com/en-us/dotnet/api/system.io.file).  Но этот метод кажется мне особенно нужным.